### PR TITLE
Fix typo to make Mobile Menu consistent with Desktop Nav Links

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -86,7 +86,7 @@
           </a>
           <hr class="dark-gray border-bottom my2">
           <ul class='white list-reset h2 sm-h1'>
-            {% assign pages_list = site.pages | sort: "nav-order" %}
+            {% assign all_pages = site.pages | sort: "nav-order" %}
             {% assign group = 'navigation' %}
             {% include pages_list mobile=true %}
             {% if include.no-button  == nil %}


### PR DESCRIPTION
Just a small change to fix the broken Hamburger button on mobile devices

Issue: https://github.com/voteflux/vote-flux-v2/issues/4
