### PR TITLE
Fix for broken member counter on about/how page

### DIFF
--- a/_includes/components/inline-signup.html
+++ b/_includes/components/inline-signup.html
@@ -6,7 +6,7 @@
         <h2 class="bold">Join the movement</h2>
         <h3 class="mb3">Modernise our democratic system</h3>
         <hr class="border-bottom muted silver">
-        <h4 class="sm-h3"><span id="js-member-count" class="bold">Loading...</span> members registered</h4>
+        <h4 class="sm-h3"><span class="js-member-count" class="bold">Loading...</span> members registered</h4>
         <h4 class='line-height-4 sm-h4'>Flux is now a federally registered <br> political party! <a href="http://www.aec.gov.au/parties_and_representatives/party_registration/Registered_parties/voteflux.htm">See AEC website for details</a></h4>
       </div>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
             <!-- <span class="border-top inline-block flux-logo-width"></span>
             <div>
               <h5 class="muted caps">Registered<br>Members</h5>
-              <h3><span id="js-member-count-footer">Loading...</span></h3>
+              <h3><span class="js-member-count-footer">Loading...</span></h3>
             </div> -->
           </div>
           <div class="sm-col-4 px2">

--- a/index.html
+++ b/index.html
@@ -102,9 +102,9 @@ social-media:
         </div>
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
-          <h3><span class="js-member-count-mobile">Loading...</span></h3>
+          <h3><span class="js-member-count">Loading...</span></h3>
           <h5 class="muted caps mt3">Volunteers</h5>
-          <h3><span class="js-volunteer-count-mobile">Loading...</span></h3>
+          <h3><span class="js-volunteer-count">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -103,6 +103,8 @@ social-media:
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
           <h3><span class="js-member-count">Loading...</span></h3>
+          <h5 class="muted caps mt3">WA Registered<br>Members</h5>
+          <h3> <span class="js-wamember-count">Loading...</span> </h3>
           <h5 class="muted caps mt3">Volunteers</h5>
           <h3><span class="js-volunteer-count">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>

--- a/index.html
+++ b/index.html
@@ -74,11 +74,11 @@ social-media:
                 <hr class="muted border-bottom black width-8rem left my2">
               </div>
               <h5 class="muted caps">Registered<br>Members</h5>
-              <h3> <span id="js-member-count">Loading...</span> </h3>
+              <h3> <span class="js-member-count">Loading...</span> </h3>
               <h5 class="muted caps">WA Registered<br>Members</h5>
-              <h3> <span id="js-wamember-count">Loading...</span> </h3>
+              <h3> <span class="js-wamember-count">Loading...</span> </h3>
               <h5 class="muted caps">Volunteers</h5>
-              <h3> <span id="js-volunteer-count">Loading...</span> </h3>
+              <h3> <span class="js-volunteer-count">Loading...</span> </h3>
               <h5 class="muted caps"> <a href="/dashboard">Graphs</a> </h5>
             </div>
           </div>
@@ -102,9 +102,9 @@ social-media:
         </div>
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
-          <h3><span id="js-member-count-mobile">Loading...</span></h3>
+          <h3><span class="js-member-count-mobile">Loading...</span></h3>
           <h5 class="muted caps mt3">Volunteers</h5>
-          <h3><span id="js-volunteer-count-mobile">Loading...</span></h3>
+          <h3><span class="js-volunteer-count-mobile">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -103,11 +103,11 @@ social-media:
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
           <h3><span class="js-member-count">Loading...</span></h3>
-          <h5 class="muted caps mt3">WA Registered<br>Members</h5>
+          <h5 class="muted caps mt2">WA Registered<br>Members</h5>
           <h3> <span class="js-wamember-count">Loading...</span> </h3>
-          <h5 class="muted caps mt3">Volunteers</h5>
+          <h5 class="muted caps mt2">Volunteers</h5>
           <h3><span class="js-volunteer-count">Loading...</span></h3>
-          <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
+          <h5 class="muted caps mt2"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -262,22 +262,30 @@ $(document).ready(function() {
       },
       success: function(response) {
         var data = JSON.parse(response);
-        var el = document.getElementById("js-member-count");
-        var wa = document.getElementById("js-wamember-count");
-        var elMobile = document.getElementById("js-member-count-mobile");
-        var volCountEl = document.getElementById("js-volunteer-count");
-        var volCountElMobile = document.getElementById("js-volunteer-count-mobile");
+        var dataArray = {
+          "js-member-count": data.n_members,
+          "js-wamember-count": data.n_members_state.wa,
+          "js-volunteer-count": data.n_volunteers,
+          // TS: No need to differentiate between mobile and non-mobile here for now
+          // "js-member-count-mobile": data.n_members,
+          // "js-volunteer-count-mobile": data.n_volunteers
+        };
 
         var set_contents = function(e, to_set){
           if(Boolean(e))
             e.innerHTML = to_set;
         }
 
-        set_contents(el, data.n_members);
-        set_contents(volCountEl, data.n_volunteers);
-        set_contents(wa, data.n_members_state.wa);
-        set_contents(elMobile, data.n_members);
-        set_contents(volCountElMobile, data.n_volunteers);
+        for (var key in dataArray) {
+          var value = dataArray[key];
+          var ref = document.getElementsByClassName(key);
+          // Some pages have more than one member counter
+          for (var i = 0, len = ref.length; i < len; i++) {
+            var element = ref[i];
+            set_contents(element, value);
+          }
+        }
+
       },
       type: 'GET'
     });

--- a/wa-landinghome.html
+++ b/wa-landinghome.html
@@ -76,11 +76,11 @@ social-media:
                 <hr class="muted border-bottom black width-8rem left my2">
               </div>
               <h5 class="muted caps">Registered<br>Members</h5>
-              <h3> <span id="js-member-count">Loading...</span> </h3>
+              <h3> <span class="js-member-count">Loading...</span> </h3>
               <h5 class="muted caps">WA Registered<br>Members</h5>
-              <h3> <span id="js-wamember-count">Loading...</span> </h3>
+              <h3> <span class="js-wamember-count">Loading...</span> </h3>
               <h5 class="muted caps">Volunteers</h5>
-              <h3> <span id="js-volunteer-count">Loading...</span> </h3>
+              <h3> <span class="js-volunteer-count">Loading...</span> </h3>
               <h5 class="muted caps"> <a href="/dashboard">Graphs</a> </h5>
             </div>
           </div>
@@ -104,9 +104,9 @@ social-media:
         </div>
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
-          <h3><span id="js-member-count-mobile">Loading...</span></h3>
+          <h3><span class="js-member-count-mobile">Loading...</span></h3>
           <h5 class="muted caps mt3">Volunteers</h5>
-          <h3><span id="js-volunteer-count-mobile">Loading...</span></h3>
+          <h3><span class="js-volunteer-count-mobile">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>

--- a/wa-landinghome.html
+++ b/wa-landinghome.html
@@ -104,9 +104,9 @@ social-media:
         </div>
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
-          <h3><span class="js-member-count-mobile">Loading...</span></h3>
+          <h3><span class="js-member-count">Loading...</span></h3>
           <h5 class="muted caps mt3">Volunteers</h5>
-          <h3><span class="js-volunteer-count-mobile">Loading...</span></h3>
+          <h3><span class="js-volunteer-count">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>

--- a/wa-landinghome.html
+++ b/wa-landinghome.html
@@ -105,6 +105,8 @@ social-media:
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
           <h3><span class="js-member-count">Loading...</span></h3>
+          <h5 class="muted caps mt3">WA Registered<br>Members</h5>
+          <h3> <span class="js-wamember-count">Loading...</span> </h3>
           <h5 class="muted caps mt3">Volunteers</h5>
           <h3><span class="js-volunteer-count">Loading...</span></h3>
           <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>

--- a/wa-landinghome.html
+++ b/wa-landinghome.html
@@ -105,11 +105,11 @@ social-media:
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
           <h3><span class="js-member-count">Loading...</span></h3>
-          <h5 class="muted caps mt3">WA Registered<br>Members</h5>
+          <h5 class="muted caps mt2">WA Registered<br>Members</h5>
           <h3> <span class="js-wamember-count">Loading...</span> </h3>
-          <h5 class="muted caps mt3">Volunteers</h5>
+          <h5 class="muted caps mt2">Volunteers</h5>
           <h3><span class="js-volunteer-count">Loading...</span></h3>
-          <h5 class="muted caps mt3"> <a href="/dashboard">Graphs</a> </h5>
+          <h5 class="muted caps mt2"> <a href="/dashboard">Graphs</a> </h5>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://voteflux.org/about/how/
<img width="845" alt="screen shot 2016-11-01 at 4 11 37 pm" src="https://cloud.githubusercontent.com/assets/23013276/19894974/3cb0a356-a04f-11e6-9715-17549a9494f6.png">

The first member counter works fine, but the second member counter near the bottom of the page is broken. This is because getElementById only gets the first element because id's should be unique.
Since there can be multiple instances of counters on the same page (as in the about/how page, but also on the front page) I have changed all instances of js-member-counter etc. from id to class.

I also refactored the getMembers function to be a bit more programmatic, and I have also removed the -mobile version of the js-member-counter since I assume this was added to fix the above problem of id's being unique, but it is no longer required when using classes.