### PR TITLE
Add GA Enhanced Link Attribution

### DIFF
--- a/_includes/javascripts.html
+++ b/_includes/javascripts.html
@@ -20,6 +20,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-62282050-2', 'auto');
+  ga('require', 'linkid');
   ga('send', 'pageview');
 </script>
 <!-- Google Analytics end -->

--- a/react-signup/app/index.html
+++ b/react-signup/app/index.html
@@ -72,6 +72,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', 'UA-62282050-2', 'auto');
+    ga('require', 'linkid');
     ga('send', 'pageview');
   </script>
   <!-- Google Analytics end -->


### PR DESCRIPTION
Just trying to get more detailed in-page analytics by following these instructions
https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-link-attribution

At the moment the in-page analytics just groups together all links that point to the same place.
According to the instructions above, we may also need to add unique id's to each link to get this working.
I'm not sure why it's not working for the Become a Member button though.. That would be very handy...
![screen shot 2016-11-21 at 10 22 28 pm](https://cloud.githubusercontent.com/assets/23013276/20501173/047442b4-b039-11e6-970d-c0f149e78f59.png)
