### PR TITLE
AD-36 Update Candidates Page

### DIFF
--- a/candidates.html
+++ b/candidates.html
@@ -2,7 +2,7 @@
 layout: default
 permalink: /candidates/
 dark-theme: true
-title: Flux candidates
+title: 2016 Federal Election Candidates
 ---
 
 {% include navbar.html %}
@@ -11,7 +11,7 @@ title: Flux candidates
     <div class=" mt4">
 
       {% include components/main-heading.html
-        text="Meet the candidates"
+        text="2016 Federal Election Candidates"
         font-size="h0 line-height-2"
         font-weight="bold"
         line="true" %}
@@ -20,6 +20,7 @@ title: Flux candidates
         <h3 class="h3 sm-h2 letter-spacing-2 line-height-3 mb2">Flux Senators serve to protect the integrity of Flux. </h3>
         <p class="h4 light sm-h3 letter-spacing-3 silver">Being a Flux Senator is not like being any other Senator. Flux Senators respect Flux as a method for decision making more than they respect their own opinions. If elected, this may mean casting a vote in the Senate contrary to their personal beliefs.</p>
         <p class="h4 light sm-h3 letter-spacing-3 silver">All our Flux candidates have made a public declaration stating that they will act as a proxy for the Flux system and that they won't use their status for personal gain (including personal policy agenda).</p>
+        <p class="h4 light sm-h4 letter-spacing-3">N.B. Candidates for the 2017 WA State Election have not yet been selected.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I think this is better than removing the Candidates Page, like we discussed this morning. Especially since we don't really have anywhere to redirect them too at the moment.

<img width="1270" alt="screen shot 2017-01-30 at 4 23 55 pm" src="https://cloud.githubusercontent.com/assets/23013276/22413061/8a3f1f62-e708-11e6-8aa3-af7cbbb54a5c.png">
