### PR TITLE
Update parallelshell to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash.throttle": "^4.0.1",
     "moment": "^2.13.0",
     "node-sass": "^4.5.3",
-    "parallelshell": "^2.0.0",
+    "parallelshell": "3.0.2",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-modal": "^1.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5790,9 +5790,9 @@ pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
 
-parallelshell@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/parallelshell/-/parallelshell-2.0.0.tgz#c94af5d6348526a26da9020faeb5fc724a80600c"
+parallelshell@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/parallelshell/-/parallelshell-3.0.2.tgz#fffc55aaa145bdd44b5381cf7fd5e521fc21aa7b"
 
 param-case@2.1.x:
   version "2.1.1"


### PR DESCRIPTION
Getting error when running `yarn flux`

```
TypeError: "cwd" must be a string
    at normalizeSpawnArguments (child_process.js:401:11)
```

Has been fixed here https://github.com/darkguy2008/parallelshell/issues/57#issuecomment-307984089
So I'm updating parallelshell to 3.0.2 which includes the fix.