### PR TITLE
Redo recent posts + some refactors

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -119,6 +119,9 @@ ReCAPTCHAv3
 DigitalDemocracy
 iOS
 deregistered
+bono
+e.g.
+suboptimal
  - _posts/2016-09-18-party-meeting-2016-09-19.md
 https
  - _posts/2016-09-18-public-meetings.md

--- a/_config.yml
+++ b/_config.yml
@@ -54,12 +54,10 @@ future: true
 candidates: false
 countdown: false
 social-media:
-- name: facebook
-  url: https://facebook.com/voteflux.org
 - name: discord
   url: https://discord.io/FluxParty
-- name: slack
-  url: https://voteflux.org/slack
+- name: facebook
+  url: https://facebook.com/voteflux.org
 - name: twitter
   url: https://twitter.com/voteflux
 - name: reddit

--- a/_includes/components/main-heading.html
+++ b/_includes/components/main-heading.html
@@ -2,7 +2,12 @@
   <h2 id={{include.text | slugify }} class="mb0 {% if include.font-size %}{{include.font-size}} {% else %}h1 {% endif %}{% if include.font-weight %}{{include.font-weight}} {% else %} bold {% endif %} {{include.classes}} line-height-2"> {{include.text}}
   </h2>
   {% if include.sub-text %}
-  <h3>{{include.sub-text}}</h3>
+  <h2 class="mt2 line-height-2
+    {% if include.sub-font-size %}{{ include.sub-font-size }} {% else %}h2 {% endif %}
+    {{include.classes}}
+  ">
+    {{include.sub-text}}
+  </h2>
   {% endif %}
   {% if include.line %}
   <div class="mt2">

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -2,28 +2,23 @@
   <div class="md-col-4 px2 mb3">
     {% include components/hr-muted.html %}
     <h2 class="bold mb3">Email</h2>
-    <p class="h3 bold h-font mb3 light line-height-3"> Currently the best way to get in contact is via email:</p>
+    <p class="h3 bold mb3 light line-height-3"> Currently the best way to get in contact is via email:</p>
     <hr class="white muted border-bottom m0">
     <div class="mb3">
-      <h5 class="caps">General questions</h5>
-      <h3 class="bold h-font mt0">questions@voteflux.org</h3>
+      <h5 class="caps">The Leadership</h5>
+      <h3 class="bold mt0">leadership@voteflux.org</h3>
+      {% comment %} <h3 class="bold mt0">steerco@voteflux.org</h3> {% endcomment %}
     </div>
     <hr class="white muted border-bottom m0">
     <div class="mb3">
       <h5 class="caps">Media Enquiries</h5>
-      <h3 class="bold h-font mt0">media@voteflux.org</h3>
-      <h3 class="bold h-font mt0">media.wa@voteflux.org</h3>
-    </div>
-    <hr class="white muted border-bottom m0">
-    <div class="mb3">
-      <h5 class="caps">The Leadership</h5>
-      <h3 class="bold h-font mt0">leadership@voteflux.org</h3>
-      <h3 class="bold h-font mt0">steerco@voteflux.org</h3>
+      <h3 class="bold mt0">media@voteflux.org</h3>
+      <h3 class="bold mt0">media.wa@voteflux.org</h3>
     </div>
     <hr class="white muted border-bottom m0">
     <div class="mb3">
       <h5 class="caps">Campaign and Field Coordination</h5>
-      <h3 class="bold h-font mt0">campaign@voteflux.org</h3>
+      <h3 class="bold mt0">campaign@voteflux.org</h3>
     </div>
   </div>
   <div class="md-col-4 px2 mb3">
@@ -35,33 +30,33 @@
         <div class="">
           <img src="{{site.baseurl}}/img/social-icons/{{social.name}}-with-circle.svg" alt="{{social.name}}" width="36" class="mr2" />
         </div>
-        <h3 class="bold h-font inline-block hover-show-child"><a href="{{ social.url }}" class="accent accent-on-hover transition-fast">{{ social.name | capitalize }}</a><i class="material-icons icon-adjust muted">call_made</i></h3>
+        <h3 class="inline-block hover-show-child"><a href="{{ social.url }}" class="accent accent-on-hover transition-fast">{{ social.name | capitalize }}</a><i class="material-icons icon-adjust muted">call_made</i></h3>
       </div>
     {% endfor %}
   </div>
 
   <div class="md-col-4 px2 mb3">
     {% include components/hr-muted.html %}
-    
-    <!--
-    <h2 class="bold mb3">Community Forum</h2>
 
-      <div class="my2 mb3">
-        <p class="h3 bold h-font mb3 light line-height-3"> If you'd like to know about technical details or sociopolitical theories you can talk to us on our Community Forum</p>
-        <div class="hover-show-child">
-          <a href="https://forum.flux.party/" class="h3 border-bottom">Join the discussion!</a><i class="material-icons icon-adjust muted">call_made</i>
-        </div>
-      </div>
-    <hr class="white muted border-bottom m0">
-    -->
-    
     <h2 class="bold mt3 mb3">Volunteers Chat</h2>
 
       <div class="my2">
-        <p class="h3 bold h-font mb3 light line-height-3"> If you want to help us out with campaign efforts or otherwise, come and say hi on our Discord server. </p>
+        <p class="h3 bold mb3 light line-height-3"> If you want to help us out with campaign efforts or otherwise, come and say hi on our Discord server. </p>
         <div class="hover-show-child">
           <a href="https://discord.io/FluxParty" class="h3 border-bottom">Join the chat!</a><i class="material-icons icon-adjust muted">call_made</i>
         </div>
       </div>
+
+    {% include components/hr-muted.html %}
+
+    <h2 class="bold mt3 mb3">Forum</h2>
+
+    <div class="my2">
+      <p class="h3 bold mb3 light line-height-3">(October 2020) We've started setting up a forum again. It's pretty raw atm but completely functional.</p>
+      <div class="hover-show-child">
+        <a href="https://forum.voteflux.org" class="h3 border-bottom">forum.voteflux.org</a><i class="material-icons icon-adjust muted">call_made</i>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -5,7 +5,7 @@ header-theme: light
 
 {% include base.html %}
 {% include navbar.html%}
-<div class="full-bg-img height-30vh">
+<div class="full-bg-img height-10vh">
 </div>
 <main class="bg-white mid-gray pb4 pt3 sm-pt5 px2 sm-px3">
   <div class="mx-auto max-width-3">
@@ -13,15 +13,26 @@ header-theme: light
         <h4 class=" mt1">
           {% if page.tag-section %}
           <span class="muted"> {{ page.tag-section | upcase }} </span>
-          <span> / </span>
+          {% comment %} <!-- #47 = / --> {% endcomment %}
+          <span> &#47; </span>
           <span class="bold"> {{ page.tag-topic | upcase }} </span>
           {% endif %}
         </h4>
         <div class="sm-mb4 mb3">
+          {% capture heading-font-size %}
+            {% if page.is-hero-like %} h00-5 {%else%} h0 {%endif%}
+          {% endcapture %}
+
+          {% capture subheading-font-size %}
+            {% if page.is-hero-like %} h0-5 {%else%} h1 {%endif%} regular
+          {% endcapture %}
+
           {% include components/main-heading.html
             text=page.title
-            font-size="h0"
+            font-size=heading-font-size
             font-weight="bold"
+            sub-text=page.subtitle
+            sub-font-size=subheading-font-size
             line="true" %}
             <div class="font-noto-serif">
               {% if page.author %}
@@ -37,8 +48,13 @@ header-theme: light
         </div>
 
         <div class="break-word">
-          <!--{{ content }}-->
-          {% include anchor_headings.html html=content beforeHeading=true anchorBody='#' %}
+          {% comment %}<!--{{ content }}-->{% endcomment %}
+          {% comment %} By breaking out page.press-release in this way, it will not be included in page.extract {% endcomment %}
+          {% capture content_w_extra %}
+            {% if page.press-release %}<em><strong>{{ page.press-release }}</strong></em> {% endif %}
+            {{content}}
+          {% endcapture %}
+          {% include anchor_headings.html html=content_w_extra beforeHeading=true anchorBody='#' %}
           {% include talkyard-comments.html %}
         </div>
         <div class="mb4">

--- a/_posts/2017-05-26-flux-philosophy-whitepaper.md
+++ b/_posts/2017-05-26-flux-philosophy-whitepaper.md
@@ -1,0 +1,18 @@
+---
+title: Philosophy Whitepaper
+date: 2017-05-26
+author: Max Kaye
+layout: post
+excerpt_separator: <!--end-excerpt-->
+---
+
+Flux's philosophy whitepaper *Redefining Democracy* has now been published, and we'd like to invite you to read it.
+
+**Abstract:** This paper identifies fundamental flaws in our current democratic systems and explains that while they were useful previously, no longer serve their purpose and need to be replaced. We will explain how authority in democracy acts as a restriction on political progress, and describe a new model of democracy which removes authority from decision making, allowing a new era of political prosperity.
+
+<!--end-excerpt-->
+
+<a href="{{ site.baseurl }}/pdf/Redefining Democracy - Kaye & Spataro 1.0.2.pdf"
+    class="h3 sm-h2 border-bottom accent inline-block">
+    Read Redefining Democracy
+</a>

--- a/_posts/2019-03-06-flux-most-transparent-political-party.md
+++ b/_posts/2019-03-06-flux-most-transparent-political-party.md
@@ -8,8 +8,6 @@ redirects:
   - /transparency/
 ---
 
-*(There is a note to journalists at the conclusion of this article.)*
-
 Morality is, by definition, our best ideas on how to live. It is incredibly important.
 At Flux, we care about living and acting with integrity and morality, in all we do.
 Like all people and organisations, we're fallible, so taking our values seriously means that sometimes we'll make mistakes, but also that we're open to the criticism that will help us improve.

--- a/_posts/2020-08-03-incident-report-20200726.md
+++ b/_posts/2020-08-03-incident-report-20200726.md
@@ -1,10 +1,11 @@
 ---
 title: "Incident Report: Anomalous Sign-Ups on July 25th and 27th"
-summary: This post details an incident occurring on July 25th and 27th where a large number of anomalous member sign-up requests were made to our API, the impact of said incident, our response, and future actions.
 author: Max Kaye
 layout: about
 date: 2020-08-03
 ---
+
+This post details an incident occurring on July 25th and 27th where a large number of anomalous member sign-up requests were made to our API, the impact of said incident, our response, and future actions.
 
 ## Events
 

--- a/_posts/2020-08-08-Launching-DigiPol-app-for-WA21.md
+++ b/_posts/2020-08-08-Launching-DigiPol-app-for-WA21.md
@@ -1,22 +1,22 @@
 ---
 title: "Flux launching DigiPol app for WA 2021 State Election"
+subtitle: Bringing Digital Democracy to WA 2021
 date: 2020-08-08
 layout: about
 author: Daithí Gleeson
 redirects:
   - /wa-posts/2020-08-08-Launching-DigiPol-app-for-WA21/
 state: WA
+press-release: 08 August 2020 (PERTH)
 ---
 
-## Bringing Digital Democracy to WA 2021
-
-**_08 August 2020 (PERTH)_** – The Flux Party is releasing a technical preview our app DigiPol to bring #DigitalDemocracy to the WA state election in March 2021. The app is designed to give people access to a digital parliament on their smartphones. It has been developed by an open source community of developers and testing among Flux members for a number of months. In the coming weeks, more Flux members and the general public will be invited to join the platform.
+The Flux Party is releasing a technical preview our app DigiPol to bring #DigitalDemocracy to the WA state election in March 2021. The app is designed to give people access to a digital parliament on their smartphones. It has been developed by an open source community of developers and testing among Flux members for a number of months. In the coming weeks, more Flux members and the general public will be invited to join the platform.
 
 The timing of the release is aligned for the WA state election, something we have incorporated in to our strategy for the upcoming campaign. The long-term campaign objective has always focused on building a general awareness of the Flux ideas to support use and adoption of our app upon launch. We have thousands of registered members and many more in the general public who have expressed keen interest in our idea of an app over the years - and now we're going to find out what they think of it.
 
 Four years ago people were still somewhat hesitant about using their phones for secure transactions. In that time, we have seen significant widespread adoption of phones to manage our personal communications and finances. We've also spent that time building our technology to let voters use their phones for one more important part of their lives - having a valid input into political decisions.
 
-We're not talking about online elections. We're talking about starting with a simple digital direct democracy. People use the app to find the bills and issues they care about. They read up about them and if they want, they can show their support or opposition by voting via a secure process that protects their privacy. 
+We're not talking about online elections. We're talking about starting with a simple digital direct democracy. People use the app to find the bills and issues they care about. They read up about them and if they want, they can show their support or opposition by voting via a secure process that protects their privacy.
 
 We invite you to test our our app. If after trying it, you don't think it's a good idea... we'll be surprised, but very well. Best wishes to you.
 

--- a/_posts/2020-10-08-how-many-political-parties-can-you-be-a-member-of.md
+++ b/_posts/2020-10-08-how-many-political-parties-can-you-be-a-member-of.md
@@ -1,5 +1,6 @@
 ---
 title: How many political parties can you be a member of?
+subtitle: Addressing a common misconception about political party membership
 permalink: "/how-many-political-parties-can-you-be-a-member-of/"
 redirects:
 - "/2020/10/08/how-many-political-parties-can-you-be-a-member-of/"
@@ -10,9 +11,7 @@ summary: Can you be a member of multiple political parties at the same time? Yes
 author: Daithí Gleeson
 ---
 
-# Addressing a common misconception about political party membership
-
-The answer is “As many as you like, and it mostly depends on the rules and processes of the parties.”
+In short: you can join as many as you like, but it will practically depend on the rules and processes of the parties.
 
 When someone signs up as a member of a political party, they are usually asked the following question “Are you a member of another political party?”.
 

--- a/_posts/2020-10-09-the-flux-network.md
+++ b/_posts/2020-10-09-the-flux-network.md
@@ -21,13 +21,13 @@ The most significant resource of any minor party (or independent candidate) is t
 
 One prevailing idea which has stifled the growth of minor parties, is the notion that a person can only be a member of one political party at any given time. This idea is not actually correct. A person can be a member of multiple parties at the same time, but there are some minor caveats in regard to support and registration. It’s a tangent which we fully explain in this article [“How many political parties can you be a member of?”](https://www.voteflux.org/how-many-parties-can-you-be-a-member-of).
 
-But in short, the answer is “yes as long as all the parties are ok with it”.
+But in short, the answer is “yes as long as all the parties are okay with it”.
 
 It is in this light that we introduce the idea of the Flux Network.
 
 # What is the Flux Network?
 
-The Flux Network is a network of people, multiple political parties, organisations and causes, who practice Digital Democracy via the ecosystem of applications developed and released by The Flux Foundation.
+The Flux Network is a network of people, multiple political parties, organisations, causes and who practice Digital Democracy via the ecosystem of applications developed and released by The Flux Foundation.
 
 The Flux Network is more of a paradigm for some alignment and cooperation, rather than an official association of members and parties, with hard coded obligations and expectations.
 
@@ -41,7 +41,7 @@ Minor parties are often characterised by having a narrow scope of interests in r
 
 To maximise their performance at elections, the party will focus on the single-issue, but their members and supporters will undoubtedly care about other issues beyond the scope of the party’s single objective. The misconceptions mentioned above will often prevent the supporters and members of minor parties from participating in other issues. The only other way to participate on other issues they care about is by assigning a preference to another party on election day.
 
-This situation is suboptimal for all the minor parties as the current conceptions regarding party membership forces segmentation of voters into different groups, who otherwise may be strongly aligned on a wide variety of issues. Using NSW 2019 State election as an example, how many people in Keep Sydney Open would support Voluntary Euthanesia, and vice versa?
+This situation is suboptimal for all the minor parties as the current conceptions regarding party membership forces segmentation of voters into different groups, who otherwise may be strongly aligned on a wide variety of issues. Using NSW 2019 State election as an example, how many people in Keep Sydney Open would support Voluntary Euthanasia, and vice versa?
 
 The Flux Network is intended as a place for the supporters of minor parties and independents to come together to leverage the power of their numbers which have been limited due to fragmentation into different parties.
 

--- a/_posts/2020-10-09-the-flux-network.md
+++ b/_posts/2020-10-09-the-flux-network.md
@@ -1,15 +1,17 @@
 ---
 title: "The Flux Network"
-date: 2020-10-08 13:00
+subtitle: Connecting issues, parties and voters
+is-hero-like: true
+date: 2020-10-09 13:00
 layout: about
 author: Daithí Gleeson
+redirects:
+- /2020/10/08/The-Flux-Network/
 ---
 
-## Connecting issues, parties and voters
-
-> If you want to go fast, go alone.
-> If you want to go far, go together.
-> - African proverb
+> *If you want to go fast, go alone.<br>
+> If you want to go far, go together.*<br>
+> &mdash; African proverb
 
 There are challenges associated with being a minor party or independent candidate in modern Australian politics. Contesting elections and the general administration of a party are very time and energy intensive activities. Add into this mix, the fact that almost all people involved in minor parties are general volunteers or specialists working pro bono. The effort that is put in by all these people is significant, yet still does not come close to the ability of the major parties to deploy resources - and nowhere is this more obvious than when it comes to contesting elections.
 
@@ -22,7 +24,6 @@ One prevailing idea which has stifled the growth of minor parties, is the notion
 But in short, the answer is “yes as long as all the parties are ok with it”.
 
 It is in this light that we introduce the idea of the Flux Network.
-
 
 # What is the Flux Network?
 

--- a/_sass/_type-scale.scss
+++ b/_sass/_type-scale.scss
@@ -7,10 +7,14 @@ $breakpoint-lg: '(min-width: 64em)' !default;
 
 /* Basscss Type Scale */
 
-.h00 {font-size: $h0 }
-.h0 { font-size: $h1 }
+.h00 {font-size: $h00 }
+.h00-5 {font-size: $h00-5}
+.h0 { font-size: $h0 }
+.h0-5 {font-size: $h0-5}
 .h1 { font-size: $h1 }
+.h1-5 {font-size: $h1-5}
 .h2 { font-size: $h2 }
+.h2-5 {font-size: $h2-5}
 .h3 { font-size: $h3 }
 .h4 { font-size: $h4 }
 .h5 { font-size: $h5 }

--- a/_sass/_typography.scss
+++ b/_sass/_typography.scss
@@ -8,7 +8,7 @@
 
 .bold    { font-weight: $bold-font-weight /* Fallback value:  bold */ }
 
-.mid { font-weight: 700 }
+.mid { font-weight: $mid-font-weight }
 
 .regular { font-weight: $regular-font-weight }
 

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -126,7 +126,7 @@ a {
 .default {
   cursor: default;
 }
-.h-font {font-family: $heading-font; }
+.h-font { font-family: $heading-font; }
 
 .chevron {
   &:after {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -2,11 +2,17 @@
 
 // typography
 $font-family: -apple-system, BlinkMacSystemFont, 'Roboto', 'Segoe UI', 'Helvetica Neue', Helvetica, sans-serif !default;
+// this is not the heading font, but whatever. It's used in a bunch of places but I don't like it much. -MK
 $heading-font: 'Roboto Slab' !default;
+$serif-font: 'Noto Serif' !default;
 $h00: 8rem !default;
+$h00-5: 5.66rem !default;  // sqrt(8*4);
 $h0: 4rem !default;
+$h0-5: 2.83rem !default;  // sqrt(4*2);
 $h1: 2rem !default;
+$h1-5: 1.73rem !default;  // sqrt(2*1.5);
 $h2: 1.5rem !default;
+$h2-5: 1.37rem !default;  // sqrt(1.5*1.25);
 $h3: 1.25rem !default;
 $h4: 1rem !default;
 $h5: .875rem !default;
@@ -23,6 +29,7 @@ $caps-letter-spacing: .2em !default;
 $light-font-weight: 300 !default;
 $mid-light-font-weight: 300 !default;
 $regular-font-weight: 400 !default;
+$mid-font-weight: 600 !default;
 $bold-font-weight: 900 !default;
 
 // layout

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ show_fundrazr: false
         font-size="h0 line-height-2"
         font-weight="bold"
         classes="letter-spacing-1 mb2 sm-mb4 md-mt4 md-pt4 near-white" %}
-        <p class="h3 sm-h2 h-font light mb4 silver letter-spacing-2 line-height-4">
+        <p class="h3 sm-h2 light mb4 silver letter-spacing-2 line-height-4">
           {{ page.hero-copy }}
         </p>
         <div class="md-flex">
@@ -98,17 +98,22 @@ show_fundrazr: false
             </a>
             <span class="gray h3 block caps mt1 letter-spacing-1">Membership is free for life</span>
           </div>
-          <!-- [TS] HTV announcement is over -->
+          <!-- Most Recent Post -->
+          {% if page.show-most-recent-post %}
           <div class="lg-col-6 md-col-12 light silver align-top md-mt0 mt3 md-pl2">
-            <h2 class="mt0 pt0">Most recent post: <a href="#announcements">(see all)</a></h2>
-            {% for post in site.posts limit:1 %}<a class="underline" href="{{ post.url }}">{{ post.title }}</a> <small>&mdash; {{ post.date | date: "%Y-%m-%d" }}</small><br>
+            <h3 class="mt0 pt0 light mb1">Most recent post: </h3>
+            {% for post in site.posts limit:1 %}
+              <a class="h2 regular underline" href="{{ post.url }}">{{ post.title }}</a>
+              <span class="h2 light">&mdash; {{ post.date | date: "%Y-%m-%d" }}</span>
+              {% comment %} <br>
               {% if post.summary %}
                 {{post.summary}}
               {% else %}
                 {{post.excerpt}}
-              {% endif %}
+              {% endif %} {% endcomment %}
             {% endfor %}
           </div>
+          {% endif %}
         </div>
         <div class="md-hide lg-hide silver">
           <h5 class="muted caps mt3">Registered Members</h5>
@@ -118,6 +123,45 @@ show_fundrazr: false
 
           <h5 class="muted caps mt2"> <a href="/dashboard">Graphs</a> </h5>
         </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Recent Posts -->
+<section class="bg-white py4 px2 md-px3">
+  <div class="max-width-4 mx-auto dark-gray">
+    <div class="md-flex mb3">
+      <div class="md-col-12">
+        <h1 class="h0 bold mb3 line-height-2">
+          Recent Posts
+        </h1>
+        {% for post in site.posts | limit:5 %}
+        <div class="">
+          <!-- this size just happens to line up with the date quite nicely -->
+          <span class="border-bottom px4 mt2 inline-block border-thin muted accent"></span>
+          <h2 class="mt0"><em>{{post.date | date: "%Y-%m-%d"}} &mdash;</em> <a href="{{post.url}}">{{ post.title }}</a></h2>
+          <p>
+            {{ post.excerpt }}
+            {% comment %} {% if post.summary %} {{ post.summary }} {% else %} {{post.excerpt}} {% endif %} {% endcomment %}
+          </p>
+        </div>
+        {% endfor %}
+
+        <div class="right">
+          <a href="{{baseurl}}/posts/" class="h1 regular pr4 pl3 pt3 pb2 block">
+            See All Posts 🡺
+          </a>
+        </div>
+
+        {% comment %} <p class="h3 sm-h2 light h-font mb4 gray letter-spacing-2 line-height-4">
+          Flux's philosophy whitepaper <em>Redefining Democracy</em> has now been published, and we'd like to invite you to read it.
+        </p>
+        <p class="h4 sm-h2 light h-font mb4 gray letter-spacing-2 line-height-4"><strong>Abstract:</strong> This paper identifies fundamental flaws in our current democratic systems and explains that while they were useful previously, no longer serve their purpose and need to be replaced. We will explain how authority in democracy acts as a restriction on political progress, and describe a new model of democracy which removes authority from decision making, allowing a new era of political prosperity.</p>
+        <a href="{{ site.baseurl }}/pdf/Redefining Democracy - Kaye & Spataro 1.0.2.pdf"
+           class="h3 sm-h2 border-bottom accent inline-block">
+          Read Redefining Democracy
+        </a> {% endcomment %}
       </div>
     </div>
   </div>
@@ -200,11 +244,11 @@ show_fundrazr: false
           font-weight="bold"
           classes="white"
           line="true" %}
-          <p class="h-font h3 sm-h2 light silver mb3">
+          <p class="h3 sm-h2 light silver mb3">
             This is us in a nutshell. We're fed up with the political process too!
             Flux is your answer for a real democratic voice in parliament.
           </p>
-          <p class="h-font h3 sm-h2 light silver"> Help us get the word out! #share </p>
+          <p class="h3 sm-h2 light silver"> Help us get the word out! #share </p>
           <div class="mb3">
             <a data-sumome-share-id="b6279140-56da-424e-9e95-54d26518c49d"></a>
           </div>
@@ -227,7 +271,9 @@ show_fundrazr: false
 {% endif %}
 
 
-<!-- Articles -->
+<!-- Philosophy Whitepaper -->
+{% if false %}
+<!-- moved to post dated 2017-05-26 which is the git history date for publishing it -->
 <section class="bg-white py4 px2 md-px3">
   <div class="max-width-4 mx-auto dark-gray">
     <div class="md-flex mb3">
@@ -235,10 +281,10 @@ show_fundrazr: false
         <h1 class="h0 bold mb3 line-height-2">
           Philosophy Whitepaper
         </h1>
-        <p class="h3 sm-h2 light h-font mb4 gray letter-spacing-2 line-height-4">
+        <p class="h3 sm-h2 light mb4 gray letter-spacing-2 line-height-4">
           Flux's philosophy whitepaper <em>Redefining Democracy</em> has now been published, and we'd like to invite you to read it.
         </p>
-        <p class="h4 sm-h2 light h-font mb4 gray letter-spacing-2 line-height-4"><strong>Abstract:</strong> This paper identifies fundamental flaws in our current democratic systems and explains that while they were useful previously, no longer serve their purpose and need to be replaced. We will explain how authority in democracy acts as a restriction on political progress, and describe a new model of democracy which removes authority from decision making, allowing a new era of political prosperity.</p>
+        <p class="h4 sm-h2 light mb4 gray letter-spacing-2 line-height-4"><strong>Abstract:</strong> This paper identifies fundamental flaws in our current democratic systems and explains that while they were useful previously, no longer serve their purpose and need to be replaced. We will explain how authority in democracy acts as a restriction on political progress, and describe a new model of democracy which removes authority from decision making, allowing a new era of political prosperity.</p>
         <a href="{{ site.baseurl }}/pdf/Redefining Democracy - Kaye & Spataro 1.0.2.pdf"
            class="h3 sm-h2 border-bottom accent inline-block">
           Read Redefining Democracy
@@ -247,6 +293,7 @@ show_fundrazr: false
     </div>
   </div>
 </section>
+{% endif %}
 
 
   <!-- PUNT  -->
@@ -261,7 +308,7 @@ show_fundrazr: false
               text="PUNT Podcast - Behind The Scenes"
               font-size="h0 line-height-2"
               font-weight="bold" %}
-            <p class="h3 sm-h2 h-font mb4 light letter-spacing-2 line-height-4 silver">
+            <p class="h3 sm-h2 mb4 light letter-spacing-2 line-height-4 silver">
               PUNT is a behind the scenes look at what it’s like to start a political party.
               It's the true story of The Flux Party. Recording for PUNT started in January, that's 4.5 months of audio!
             </p>
@@ -293,49 +340,6 @@ show_fundrazr: false
   {% endif %}
 
 
-
-  <!-- Posts -->
-  <section id="announcements" class="height-40vh py2 sm-py4 relative bg-dark-gray px2 md-px2">
-    <div class="max-width-4 mx-auto relative z2sm-pr4">
-      <div class="lg-flex mxn2">
-        <div class="lg-col-12 px2">
-          <div class="bg-near-black light-gray px3 py4 sm-p4 mb3">
-            <div class="mb3" id="blog">
-              {% include components/main-heading.html
-              text="Announcements"
-              font-size="h0 line-height-2"
-              font-weight="bold" %}
-
-              <div id="recent-posts-section">
-                {% for post in site.posts limit:1 %}
-                <div class="post">
-                  <h1 class="h1 regular"><a class="underline" href="{{ post.url }}">{{ post.title }}</a> <small>&mdash; {{ post.date | date: "%Y-%m-%d" }}</small></h1>
-                  <div class="h3 sm-h2 h-font mb4 light letter-spacing-2 line-height-4 silver">
-                    {% if post.summary %}
-                      {{post.summary}}
-                    {% else %}
-                      {{post.excerpt}}
-                    {% endif %}
-                  </div>
-                </div>
-                {% endfor %}
-                <h1 class="h1 regular">Older Announcements</h2>
-                  {% for post in site.posts offset:1 limit:10 %}
-                  <h3 class="h3 regular"><a class="underline" href="{{ post.url }}">{{ post.title }}</a> <small>&mdash; {{ post.date | date: "%Y-%m-%d" }}</small></h1>
-                {% endfor %}
-                <div class="right-align mt2">
-                  <a href="{{site.baseurl}}/blog" class="h3 border-bottom">See all announcements</a>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-
-
 <!-- WHY FLUX SECTION -->
 <section class="bg-white py4 px2 md-px3">
   <div class="max-width-4 mx-auto dark-gray">
@@ -346,7 +350,7 @@ show_fundrazr: false
         <h1 class="h0 bold mb3 line-height-2">
             {{ page.why-flux-title }}
         </h1>
-        <p class="h3 sm-h2 light h-font mb4 gray letter-spacing-2 line-height-4">
+        <p class="h3 sm-h2 light mb4 gray letter-spacing-2 line-height-4">
           {{ page.why-flux-copy }}
         </p>
         <a href="{{ site.baseurl }}/about/why-flux"
@@ -367,7 +371,7 @@ show_fundrazr: false
           text=page.second-callout-title
           font-size="h0 line-height-2"
           font-weight="bold" %}
-        <p class="h3 sm-h2 h-font mb4 light letter-spacing-2 line-height-4 silver">
+        <p class="h3 sm-h2 mb4 light letter-spacing-2 line-height-4 silver">
           {{ page.second-callout-copy }}
         </p>
       </div>
@@ -449,7 +453,7 @@ show_fundrazr: false
                   <h5 class="mb2 gray">{{ article.type | upcase }} / <span class="light-silver">{{ article.publishedIn | upcase }}</span>
                   </h5>
                   <a href="{{ article.url }}" target="_blank" class="link-reset block hover-show-child">
-                    <h3 class="h-font light line-height-4 accent-on-hover transition-fast inline">
+                    <h3 class="light line-height-4 accent-on-hover transition-fast inline">
                       {{ article.title }}
                     </h3><i class="material-icons icon-adjust muted">call_made</i>
                   </a>
@@ -469,6 +473,8 @@ show_fundrazr: false
 </section>
 
 <!-- UPCOMING MEETUPS -->
+{% if false %}
+<!-- don't reenable without considerable changes -MK -->
 {% if page.show-meetups %}
 <section id="upcoming-meetups" class="py4 bg-dark-gray light-silver">
   <div class="max-width-4 mx-auto px2 md-px3">
@@ -520,6 +526,7 @@ show_fundrazr: false
     </div>
   </div>
 </section>
+{% endif %}
 {% endif %}
 
 

--- a/posts.html
+++ b/posts.html
@@ -1,0 +1,53 @@
+---
+title: Posts
+permalink: "/posts/"
+layout: default
+dark-theme: true
+---
+
+{% include navbar.html %}
+<header class="bg-near-black texture-bg-img height-30vh py4">
+	<div class="max-width-4 mx-auto px2 sm-px3 pt5">
+	  {% include components/main-heading.html
+	    text=page.title
+	    font-size="h00"
+	    font-weight="light"
+	    line="true"
+	    classes="white" %}
+	</div>
+</header>
+
+<section class="bg-white">
+	<div class="flex flex-wrap max-width-4 mx-auto">
+		{% for post in site.posts %}
+			<article class="py0 inline-block col-12">
+				<a href="{{ post.url }}" class="max-width-12 dark-gray mx-auto px2 md-px3">
+					<div class="flex">
+						<div class="lg-col-12 px2 lg-px3 ">
+							<p class="h-font h3 sm-h2 light">
+								<small>{{ post.date | date: "%Y-%m-%d" }}</small>
+							</p>
+							<h2 class="mb0 h1 line-height-2 bold line-height-2">{{ post.title }}</h2>
+							<div class="h3 sm-h2 light mb3">
+								<p>
+									{% if post.excerpt contains '</a>' %}
+									{{post.excerpt | strip_html}}
+									{% else %}
+									{{post.excerpt}}
+									{% endif %}
+									{% comment %} {% if post.summary %}
+										{{post.summary}}
+									{% else %}
+										{{post.excerpt}}
+									{% endif %} {% endcomment %}
+								</p>
+							</div>
+						</div>
+					</div>
+				</a>
+			</article>
+		{% endfor %}
+	</div>
+</section>
+
+{% include footer.html %}


### PR DESCRIPTION
Make recent posts look nice and move it up the home page

- **add subtitle parameter to post layout so that ppl don't put a heading as first thing -- which one shouldn't do** (see flux network post)
- remove philosophy whitepaper from homepage
- add is-hero-like parameter to about layout -- makes the heading a bit bigger (see The Flux Network article)
- linked the new forum (which also does comments)
- remove link to slack
- leadership email only listed once now and 1st in list
- change most homepage fonts to be sans-serif not serif
- fix rendering of links in post extracts
- add /posts/ page with a list of all posts (note: /blog/ exists but looks shitty)
- add post 2017-05-26 with philosophy whitepaper link
- add some css stuff

### what it looks like now

![image](https://user-images.githubusercontent.com/1046448/95564207-3102a480-0a6a-11eb-9c24-0d437d00c038.png)
image 1
----
![image](https://user-images.githubusercontent.com/1046448/95564229-3a8c0c80-0a6a-11eb-88d8-a97c9a90900c.png)
image 2
----
![image](https://user-images.githubusercontent.com/1046448/95564248-3fe95700-0a6a-11eb-884a-38205b9c34fb.png)
image 3
----
![image](https://user-images.githubusercontent.com/1046448/95564266-4546a180-0a6a-11eb-9871-7f698599e602.png)
image 4
----
